### PR TITLE
add Homebrew dependency to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.2-
 BinDeps 0.2.1-
+Homebrew


### PR DESCRIPTION
otherwise one might get `ERROR: Homebrew package not installed, please run Pkg.add("Homebrew")
`
