### PR TITLE
Fedora 21 the yum package needed is gnutls

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -38,7 +38,7 @@ end
 end
 
 provides(AptGet,"libgnutls28",gnutls,validate = pkgmanager_validate) # Yes, this is the most current version, I guess they broke binary compatibility in v2.8?
-provides(Yum,"libgnutls",gnutls,validate = pkgmanager_validate)
+provides(Yum,"gnutls",gnutls,validate = pkgmanager_validate)
 
 julia_usrdir = normpath(JULIA_HOME*"/../") # This is a stopgap, we need a better builtin solution to get the included libraries
 libdirs = String["$(julia_usrdir)/lib"]


### PR DESCRIPTION
As you can see in the Dockerfile [here](https://github.com/JuliaWeb/HttpParser.jl/issues/32#issuecomment-118240269) this is the proper package name.