### PR TITLE
Close IOs when we're done

### DIFF
--- a/src/GnuTLS.jl
+++ b/src/GnuTLS.jl
@@ -116,6 +116,8 @@ function close(s::Session)
 	end
 	gnutls_error(ret)
 	s.open=false
+	close(s.read)
+	close(s.write)
 	nothing
 end
 


### PR DESCRIPTION
I have a few use-cases where I'm repeatedly doing POST requests over a couple hours and I started noticing that I'd consistently see a EATHROW or some kind of system error that was pretty cryptic. But then one time, I tried to open a csv file with `Base.open(file)` and got a "too many open file handles" error. I then checked my `lsof` and sure enough, there were pages of old TCP sockets lying around from all my POST requests.

@Keno, it's not going to break anything to close these, right? I first started debugging this through Requests.jl, but realized that it's actually the `Session` that was not doing the closing. Should we instead do the closing in Requests.jl?